### PR TITLE
DEVOPS-466: rename python_ver input variable for consistency

### DIFF
--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-workflow-create-jira-issue:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@DEVOPS-466
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@main
     secrets: inherit
     with:
       project-key: 'GEOPY'

--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-workflow-create-jira-issue:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@DEVOPS-466
     secrets: inherit
     with:
-      project_key: 'GEOPY'
+      project-key: 'GEOPY'

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -24,14 +24,14 @@ concurrency:
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-466
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@main
     with:
       package-manager: 'conda'
       app-name: 'peak_finder'
       python-version: '3.10'
   call-workflow-pytest:
     name: Pytest
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@DEVOPS-466
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@main
     with:
       package-manager: 'conda'
       python-versions: '["3.10"]'

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -29,21 +29,15 @@ jobs:
       package-manager: 'conda'
       app-name: 'peak_finder'
       python-version: '3.10'
-  call-workflow-pytest-on-windows:
-    name: Pytest on Windows
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-466
+  call-workflow-pytest:
+    name: Pytest
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest.yml@DEVOPS-466
     with:
       package-manager: 'conda'
       python-versions: '["3.10"]'
+      os: '["ubuntu-latest", "windows-latest"]'
       cache-number: 1
       codecov-reference-python-version: '3.10'
+      codecov-reference-os: '["ubuntu-latest", "windows-latest"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  call-workflow-pytest-on-unix-os:
-    name: Pytest on Unix OS
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@DEVOPS-466
-    with:
-      package-manager: 'conda'
-      python-versions: '["3.10"]'
-      os: '["ubuntu-latest"]'
-      cache-number: 1

--- a/.github/workflows/python_analysis.yml
+++ b/.github/workflows/python_analysis.yml
@@ -21,33 +21,29 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  app_name: 'peak_finder'
-  package_manager: 'conda'
-
 jobs:
   call-workflow-static-analysis:
     name: Static analysis
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-static_analysis.yml@DEVOPS-466
     with:
-      package_manager: 'conda'
-      app_name: ${{ github.env.app_name }}
-      python_vers: '3.10'
+      package-manager: 'conda'
+      app-name: 'peak_finder'
+      python-version: '3.10'
   call-workflow-pytest-on-windows:
     name: Pytest on Windows
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_windows.yml@DEVOPS-466
     with:
-      package_manager: 'conda'
-      python_ver: '["3.10"]'
-      cache_number: 1
-      codecov_reference_python_ver: '3.10'
+      package-manager: 'conda'
+      python-versions: '["3.10"]'
+      cache-number: 1
+      codecov-reference-python-version: '3.10'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   call-workflow-pytest-on-unix-os:
     name: Pytest on Unix OS
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@main
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-pytest_unix_os.yml@DEVOPS-466
     with:
-      package_manager: 'conda'
-      python_ver: '["3.10"]'
+      package-manager: 'conda'
+      python-versions: '["3.10"]'
       os: '["ubuntu-latest"]'
-      cache_number: 1
+      cache-number: 1


### PR DESCRIPTION
**DEVOPS-466 - rename python_ver input variable for consistency**
⚠️ Don't merge